### PR TITLE
Add Labeler and project board attacher

### DIFF
--- a/.github/workflows/labeler-issue-and-pr.yml
+++ b/.github/workflows/labeler-issue-and-pr.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, unlabeled]
 
 jobs:
-  add_labels_common:
+  add_label_repo:
     name: 'Add repo label to issues and PRs'
     runs-on: ubuntu-latest
     steps:
@@ -16,9 +16,9 @@ jobs:
         with:
           add-labels: GH-tooling
 
-  add_labels_mew_issue:
+  add_label_new_issue:
     name: 'Add label "NEW" to new issues'
-    needs: [add_labels_common]
+    needs: [add_label_repo]
     runs-on: ubuntu-latest
     if: github.event.issue && github.event.action == 'opened'
     steps:

--- a/.github/workflows/labeler-issue-and-pr.yml
+++ b/.github/workflows/labeler-issue-and-pr.yml
@@ -1,0 +1,28 @@
+name: Add labels to issues and PRs
+
+on:
+  issues:
+    types: [opened, unlabeled, reopened]
+  pull_request:
+    types: [opened, unlabeled]
+
+jobs:
+  add_labels_common:
+    name: 'Add repo label to issues and PRs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: GH-ACTIONS
+
+  add_labels_mew_issue:
+    name: 'Add label "NEW" to new issues'
+    needs: [add_labels_common]
+    runs-on: ubuntu-latest
+    if: github.event.issue && github.event.action == 'opened'
+    steps:
+      - name: Add label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: NEW

--- a/.github/workflows/labeler-issue-and-pr.yml
+++ b/.github/workflows/labeler-issue-and-pr.yml
@@ -1,5 +1,8 @@
 name: Add labels to issues and PRs
 
+env:
+  REPOSITORY_LABEL: GH-tooling
+
 on:
   issues:
     types: [opened, unlabeled, reopened]
@@ -14,7 +17,7 @@ jobs:
       - name: Add label
         uses: andymckay/labeler@master
         with:
-          add-labels: GH-tooling
+          add-labels: ${{ REPOSITORY_LABEL }}
 
   add_label_new_issue:
     name: 'Add label "NEW" to new issues'

--- a/.github/workflows/labeler-issue-and-pr.yml
+++ b/.github/workflows/labeler-issue-and-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Add label
         uses: andymckay/labeler@master
         with:
-          add-labels: GH-ACTIONS
+          add-labels: GH-tooling
 
   add_labels_mew_issue:
     name: 'Add label "NEW" to new issues'

--- a/.github/workflows/new_issues_to_project.yml
+++ b/.github/workflows/new_issues_to_project.yml
@@ -1,0 +1,17 @@
+name: Add new issue to Artikkelitiimi project (beta)
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  add_issue_to_project:
+    name: 'Add issue to project board (new, reopened, labelled)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Yleisradio/gh-project-actions/issues-to-project@main
+        with:
+          token: ${{secrets.GH_ACTIONS_TOKEN}}
+          project-id: 16
+          issue-id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
Add
- labeler with [`GH-tooling`](https://github.com/Yleisradio/gh-project-actions/labels/GH-tooling) as the project label
- project board attacher to put new projects (beta) board, _using this very repository's actions_