### PR TITLE
Remove the default value from input target-column

### DIFF
--- a/issues-to-project/action.yml
+++ b/issues-to-project/action.yml
@@ -27,7 +27,6 @@ inputs:
   target-column:
     description: "Kanban board target column for the issues"
     required: false
-    default: "Backlog"
   issue-id:
     description: "Id of the new issue"
     required: true


### PR DESCRIPTION
This PR removes the default value from input field `target-column`, ie. the desired status field. Effectively it means that when the `target-column` is omitted the issue will be added to the project but status is not set.

Testing this with Yleisradio/ylefi-backup-service#1